### PR TITLE
Make target_bulk and max_doc use bytes unit.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -21,16 +21,16 @@ require "uri" # for escaping user input
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #
 # ==== Template management for Elasticsearch 5.x
-# Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0. 
-# Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default 
+# Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0.
+# Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default
 # behavior.
 #
 # ** Users installing ES 5.x and LS 5.x **
 # This change will not affect you and you will continue to use the ES defaults.
 #
 # ** Users upgrading from LS 2.x to LS 5.x with ES 5.x **
-# LS will not force upgrade the template, if `logstash` template already exists. This means you will still use 
-# `.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after 
+# LS will not force upgrade the template, if `logstash` template already exists. This means you will still use
+# `.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after
 # the new template is installed.
 #
 # ==== Retry Policy
@@ -146,7 +146,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # a timeout occurs, the request will be retried.
   config :timeout, :validate => :number, :default => 60
 
-  # Set the Elasticsearch errors in the whitelist that you don't want to log. 
+  # Set the Elasticsearch errors in the whitelist that you don't want to log.
   # A useful example is when you want to skip all 409 errors
   # which are `document_already_exists_exception`.
   config :failure_type_logging_whitelist, :validate => :array, :default => []
@@ -173,7 +173,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Resurrection is the process by which backend endpoints marked 'down' are checked
   # to see if they have come back to life
   config :resurrect_delay, :validate => :number, :default => 5
-  
+
   # How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
   # You may want to set this lower, if you get connection errors regularly
   # Quoting the Apache commons docs (this client is based Apache Commmons):
@@ -183,6 +183,16 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # have become stale (half-closed) while kept inactive in the pool.'
   # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
   config :validate_after_inactivity, :validate => :number, :default => 10000
+
+  # The target size of an HTTP request in megabytes to send. Elasticsearch has a hard limit of 100MB
+  # after which it will reject the request. If the batch received by this plugin exceeds this amount
+  # it will be split up and sent in multiple requests. A request may exceed this size if there is a single
+  # document larger than it. You can limit an individuals document's size with max_doc_megabytes
+  config :target_bulk_megabytes, :validate => :number, :default => 75
+
+  # The maximum size an individual document can be without being dropped and logged
+  # Elasticsearch will not accept HTTP requests > 100MB. You likely do not want to increase this size
+  config :max_doc_megabytes, :validate => :number, :default => 90
 
   def build_client
     @client = ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)

--- a/lib/logstash/outputs/elasticsearch/byte_value.rb
+++ b/lib/logstash/outputs/elasticsearch/byte_value.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+module LogStash; module Outputs; class ElasticSearch; module ByteValue;
+  module_function
+
+  B = 1
+  KB = B << 10
+  MB = B << 20
+  GB = B << 30
+  TB = B << 40
+  PB = B << 50
+
+  def parse(text)
+    if !text.is_a?(String)
+      raise ArgumentError, "ByteValue::parse takes a String, got a `#{text.class.name}`"
+    end
+    number = text.to_f
+    factor = multiplier(text)
+
+    (number * factor).to_i
+  end
+
+  def multiplier(text)
+    case text
+      when /(?:k|kb)$/ 
+        KB
+      when /(?:m|mb)$/
+        MB
+      when /(?:g|gb)$/
+        GB
+      when /(?:t|tb)$/
+        TB
+      when /(?:p|pb)$/
+        PB
+      when /(?:b)$/
+        B
+      else 
+        raise ArgumentError, "Unknown bytes value '#{text}'"
+    end
+  end
+
+  def human_readable(number)
+    value, unit = if number > PB
+      [number / PB, "pb"]
+    elsif number > TB
+      [number / TB, "tb"]
+    elsif number > GB
+      [number / GB, "gb"]
+    elsif number > MB
+      [number / MB, "mb"]
+    elsif number > KB
+      [number / KB, "kb"]
+    else
+      [number, "b"]
+    end
+
+    format("%.2d%s", value, unit)
+  end
+end end end end

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -1,4 +1,5 @@
 require "logstash/outputs/elasticsearch/template_manager"
+require_relative "byte_value"
 
 module LogStash; module Outputs; class ElasticSearch;
   module Common

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -75,13 +75,14 @@ module LogStash; module Outputs; class ElasticSearch
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
       mod.config :hosts, :validate => :array, :default => ["127.0.0.1"]
 
+      # DEPRECATED. Prefer 'target_bulk_megabytes' setting instead
       # This plugin uses the bulk index API for improved indexing performance.
       # This setting defines the maximum sized bulk request Logstash will make
       # You you may want to increase this to be in line with your pipeline's batch size.
       # If you specify a number larger than the batch size of your pipeline it will have no effect,
       # save for the case where a filter increases the size of an inflight batch by outputting
       # events.
-      mod.config :flush_size, :validate => :number, :default => 500
+      mod.config :flush_size, :validate => :number, :default => 500, :deprecated => "Use `target_bulk_megabytes`"
 
       # The amount of time since last flush before a flush is forced.
       #

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -75,14 +75,14 @@ module LogStash; module Outputs; class ElasticSearch
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
       mod.config :hosts, :validate => :array, :default => ["127.0.0.1"]
 
-      # DEPRECATED. Prefer 'target_bulk_megabytes' setting instead
+      # DEPRECATED. Prefer 'target_bulk_bytes' setting instead
       # This plugin uses the bulk index API for improved indexing performance.
       # This setting defines the maximum sized bulk request Logstash will make
       # You you may want to increase this to be in line with your pipeline's batch size.
       # If you specify a number larger than the batch size of your pipeline it will have no effect,
       # save for the case where a filter increases the size of an inflight batch by outputting
       # events.
-      mod.config :flush_size, :validate => :number, :default => 500, :deprecated => "Use `target_bulk_megabytes`"
+      mod.config :flush_size, :validate => :number, :default => 500, :deprecated => "Use `target_bulk_bytes`"
 
       # The amount of time since last flush before a flush is forced.
       #

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -17,8 +17,8 @@ module LogStash; module Outputs; class ElasticSearch;
       # Again, in case we use DEFAULT_OPTIONS in the future, uncomment this.
       # @options = DEFAULT_OPTIONS.merge(options)
       @options = options
-      @target_bulk_bytes = @options[:target_bulk_megabytes] / 1024 / 1024
-      @max_doc_bytes = @options[:max_doc_megabytes] / 1024 / 1024
+      @target_bulk_bytes = @options[:target_bulk_bytes]
+      @max_doc_bytes = @options[:max_doc_bytes]
       @pool = build_pool(@options)
       # mutex to prevent requests and sniffing to access the
       # connection pool at the same time
@@ -62,7 +62,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
         if as_json.size > @max_doc_bytes
           @logger.warn("Document too large for ES output! Dropping",
-                        :max_doc_megabytes => @options[:max_doc_megabytes],
+                        :max_doc_bytes => @options[:max_doc_bytes],
                         :bulk_action_size => as_json.size)
           next
         end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -11,8 +11,8 @@ module LogStash; module Outputs; class ElasticSearch;
         :client_settings => client_settings,
         :resurrect_delay => params["resurrect_delay"],
         :healthcheck_path => params["healthcheck_path"],
-        :target_bulk_megabytes => params["target_bulk_megabytes"],
-        :max_doc_megabytes => params["max_doc_megabytes"]
+        :target_bulk_bytes => params["target_bulk_bytes"],
+        :max_doc_bytes => params["max_doc_bytes"]
       }
 
       if params["sniffing"]

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -10,7 +10,9 @@ module LogStash; module Outputs; class ElasticSearch;
       common_options = {
         :client_settings => client_settings,
         :resurrect_delay => params["resurrect_delay"],
-        :healthcheck_path => params["healthcheck_path"]
+        :healthcheck_path => params["healthcheck_path"],
+        :target_bulk_megabytes => params["target_bulk_megabytes"],
+        :max_doc_megabytes => params["max_doc_megabytes"]
       }
 
       if params["sniffing"]

--- a/spec/unit/outputs/elasticsearch/byte_value_spec.rb
+++ b/spec/unit/outputs/elasticsearch/byte_value_spec.rb
@@ -1,0 +1,32 @@
+require "logstash/outputs/elasticsearch/byte_value"
+require "flores/random"
+
+describe LogStash::Outputs::ElasticSearch::ByteValue do
+  let(:multipliers) do
+    {
+      "b" => 1,
+      "kb" => 1 << 10,
+      "mb" => 1 << 20,
+      "gb" => 1 << 30,
+      "tb" => 1 << 40,
+      "pb" => 1 << 50,
+    }
+  end
+
+  let(:number) { Flores::Random.number(0..100000000000).to_i }
+  let(:unit) { Flores::Random.item(multipliers.keys) }
+  let(:text) { "#{number}#{unit}" }
+
+  describe "#parse" do
+    let(:expected) { number * multipliers[unit] }
+    subject { described_class.parse(text) }
+
+    it "should return a Numeric" do
+      expect(subject).to be_a(Numeric)
+    end
+
+    it "should have an expected byte value" do
+      expect(subject).to be == expected
+    end
+  end
+end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -3,9 +3,9 @@ require "logstash/outputs/elasticsearch/http_client"
 require "java"
 
 describe LogStash::Outputs::ElasticSearch::HttpClient do
-  let(:target_bulk_megabytes) { 75 }
-  let(:max_doc_megabytes) { 90 }
-  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get, :target_bulk_megabytes => target_bulk_megabytes, :max_doc_megabytes => max_doc_megabytes }}
+  let(:target_bulk_bytes) { 75<<20 }
+  let(:max_doc_bytes) { 90<<20 }
+  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get, :target_bulk_bytes => target_bulk_bytes, :max_doc_bytes => max_doc_bytes }}
 
   describe "Host/URL Parsing" do
     subject { described_class.new(base_options) }

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -3,7 +3,9 @@ require "logstash/outputs/elasticsearch/http_client"
 require "java"
 
 describe LogStash::Outputs::ElasticSearch::HttpClient do
-  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get }}
+  let(:target_bulk_megabytes) { 75 }
+  let(:max_doc_megabytes) { 90 }
+  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get, :target_bulk_megabytes => target_bulk_megabytes, :max_doc_megabytes => max_doc_megabytes }}
 
   describe "Host/URL Parsing" do
     subject { described_class.new(base_options) }


### PR DESCRIPTION
This copies in code from https://github.com/elastic/logstash/pull/6022 for byte value parsing.

Once logstash-core supports `:validate => :bytes`, this should be able to use it without any impact to users. For now, including ByteValue in this repo.
